### PR TITLE
Use `message` key instead of `output` key in `results.json` files

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -50,7 +50,7 @@ else
     colorized_test_output=$(echo "$test_output" \
          | GREP_COLOR='01;31' grep --color=always -E -e '^.*FAILED$|$')
 
-    jq -n --arg output "${colorized_test_output}" '{version: 1, status: "fail", output: $output}' > ${results_file}
+    jq -n --arg output "${colorized_test_output}" '{version: 1, status: "fail", message: $output}' > ${results_file}
 fi
 
 echo "${slug}: done"

--- a/tests/example-all-fail/expected_results.json
+++ b/tests/example-all-fail/expected_results.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
   "status": "fail",
-  "output": "\n\n\u001b[01;31m\u001b[K==== leap-1 year not divisible by 4 in common year FAILED\u001b[m\u001b[K\n==== Contents of test case:\n\n            isLeapYear 2015\n        \n---- Result was:\n1\n---- Result should have been (exact matching):\n0\n\u001b[01;31m\u001b[K==== leap-1 FAILED\u001b[m\u001b[K\n\nexample-all-fail.test:\tTotal\t2\tPassed\t0\tSkipped\t1\tFailed\t1"
+  "message": "\n\n\u001b[01;31m\u001b[K==== leap-1 year not divisible by 4 in common year FAILED\u001b[m\u001b[K\n==== Contents of test case:\n\n            isLeapYear 2015\n        \n---- Result was:\n1\n---- Result should have been (exact matching):\n0\n\u001b[01;31m\u001b[K==== leap-1 FAILED\u001b[m\u001b[K\n\nexample-all-fail.test:\tTotal\t2\tPassed\t0\tSkipped\t1\tFailed\t1"
 }

--- a/tests/example-empty-file/expected_results.json
+++ b/tests/example-empty-file/expected_results.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
   "status": "fail",
-  "output": "\n\n\u001b[01;31m\u001b[K==== leap-1 year not divisible by 4 in common year FAILED\u001b[m\u001b[K\n==== Contents of test case:\n\n            isLeapYear 2015\n        \n---- Test generated error; Return code was: 1\n---- Return code should have been one of: 0 2\n---- errorInfo: invalid command name \"isLeapYear\"\n    while executing\n\"isLeapYear 2015\"\n    (\"uplevel\" body line 2)\n    invoked from within\n\"uplevel 1 $script\"\n---- errorCode: TCL LOOKUP COMMAND isLeapYear\n\u001b[01;31m\u001b[K==== leap-1 FAILED\u001b[m\u001b[K\n\nexample-empty-file.test:\tTotal\t9\tPassed\t0\tSkipped\t8\tFailed\t1"
+  "message": "\n\n\u001b[01;31m\u001b[K==== leap-1 year not divisible by 4 in common year FAILED\u001b[m\u001b[K\n==== Contents of test case:\n\n            isLeapYear 2015\n        \n---- Test generated error; Return code was: 1\n---- Return code should have been one of: 0 2\n---- errorInfo: invalid command name \"isLeapYear\"\n    while executing\n\"isLeapYear 2015\"\n    (\"uplevel\" body line 2)\n    invoked from within\n\"uplevel 1 $script\"\n---- errorCode: TCL LOOKUP COMMAND isLeapYear\n\u001b[01;31m\u001b[K==== leap-1 FAILED\u001b[m\u001b[K\n\nexample-empty-file.test:\tTotal\t9\tPassed\t0\tSkipped\t8\tFailed\t1"
 }

--- a/tests/example-partial-fail/expected_results.json
+++ b/tests/example-partial-fail/expected_results.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
   "status": "fail",
-  "output": "\n\n\u001b[01;31m\u001b[K==== leap-7 year divisible by 400 in leap year FAILED\u001b[m\u001b[K\n==== Contents of test case:\n\n            isLeapYear 2000\n        \n---- Result was:\n0\n---- Result should have been (exact matching):\n1\n\u001b[01;31m\u001b[K==== leap-7 FAILED\u001b[m\u001b[K\n\nexample-partial-fail.test:\tTotal\t9\tPassed\t6\tSkipped\t2\tFailed\t1"
+  "message": "\n\n\u001b[01;31m\u001b[K==== leap-7 year divisible by 400 in leap year FAILED\u001b[m\u001b[K\n==== Contents of test case:\n\n            isLeapYear 2000\n        \n---- Result was:\n0\n---- Result should have been (exact matching):\n1\n\u001b[01;31m\u001b[K==== leap-7 FAILED\u001b[m\u001b[K\n\nexample-partial-fail.test:\tTotal\t9\tPassed\t6\tSkipped\t2\tFailed\t1"
 }

--- a/tests/example-syntax-error/expected_results.json
+++ b/tests/example-syntax-error/expected_results.json
@@ -1,5 +1,5 @@
 {
   "version": 1,
   "status": "fail",
-  "output": "invalid command name \"PROCCIEE\"\n    while executing\n\"PROCCIEE isLeapYear {year} @#$&\"\n    (file \"example-syntax-error.tcl\" line 3)\n    invoked from within\n\"source \"example-syntax-error.tcl\"\"\n    (file \"example-syntax-error.test\" line 4)"
+  "message": "invalid command name \"PROCCIEE\"\n    while executing\n\"PROCCIEE isLeapYear {year} @#$&\"\n    (file \"example-syntax-error.tcl\" line 3)\n    invoked from within\n\"source \"example-syntax-error.tcl\"\"\n    (file \"example-syntax-error.test\" line 4)"
 }


### PR DESCRIPTION
This PR fixes an invalid implementation of the test runner v1 spec, where the `message` key was used instead of the `output` key in the `results.json` files

## Tracking

https://github.com/exercism/v3-launch/issues/38