### PR TITLE
Add test environment to result json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
 results.json
 results.out
 *.test.verbose
-
-# vim
-.*.sw?
-.sw?

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -11,32 +11,4 @@
 # Example:
 # ./bin/run-tests.sh
 
-exit_code=0
-
-export RUN_ALL=yes
-
-# Iterate over all test directories
-for test_dir in tests/*; do
-    test_dir_name="$(basename $test_dir)"
-    test_dir_path="$(realpath $test_dir)"
-    results_file="results.json"
-    results_file_path="${test_dir}/results.json"
-    expected_results_file="expected_results.json"
-    expected_results_file_path="${test_dir}/expected_results.json"    
-
-    if [ -f "${expected_results_file_path}" ]; then
-        echo "===="
-        bin/run.tcl "${test_dir_name}" "${test_dir}" "${test_dir}"
-        echo "===="
-
-        echo "${test_dir_name}: comparing ${results_file} to ${expected_results_file}"
-        if diff "${results_file_path}" "${expected_results_file_path}"; then
-            # exit status zero: no diff
-            echo OK
-        else
-            exit_code=1
-        fi
-    fi
-done
-
-exit ${exit_code}
+tclsh tests/test_all.test

--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -11,4 +11,4 @@
 # Example:
 # ./bin/run-tests.sh
 
-tclsh tests/test_all.test
+RUN_ALL=true tclsh tests/test_all.test

--- a/bin/run.tcl
+++ b/bin/run.tcl
@@ -156,6 +156,12 @@ proc jsonResult {status {tests {}} {message ""}} {
     set j [json object]
     json set j version [json number $::SPEC_VERSION]
     json set j status  [json string $status]
+
+    json set j "test-environment" [
+        set tools [json object]
+        json set tools tclsh [json string [info patchlevel]]
+    ] 
+
     if {$message eq ""} {
         json set j message null
     } else {

--- a/tests/testHelpers.tcl
+++ b/tests/testHelpers.tcl
@@ -1,3 +1,6 @@
+package require rl_json
+namespace import ::rl_json::json
+
 #############################################################
 # Override some tcltest procs with additional functionality
 
@@ -42,3 +45,25 @@ proc booleanMatch {expected actual} {
     }]
 }
 customMatch boolean booleanMatch
+
+
+# for testing the test runner, compare the actual results.json to the expected_results.json
+
+proc exercismResultFilesMatch {expected_file actual_file} {
+    set actual [readfile $actual_file]
+    set expected [readfile $expected_file]
+
+    expr {
+        [json get $actual version] == [json get $expected version] &&
+        [json get $actual status] eq [json get $expected status] &&
+        [json get $actual tests] eq [json get $expected tests]
+    }
+}
+customMatch exercismResultFiles exercismResultFilesMatch
+
+proc readfile {filename} {
+    set fh [open $filename]
+    set data [read $fh]
+    close $fh
+    return $data
+}

--- a/tests/testHelpers.tcl
+++ b/tests/testHelpers.tcl
@@ -56,7 +56,10 @@ proc exercismResultFilesMatch {expected_file actual_file} {
     expr {
         [json get $actual version] == [json get $expected version] &&
         [json get $actual status] eq [json get $expected status] &&
-        [json get $actual tests] eq [json get $expected tests]
+        [json get $actual tests] eq [json get $expected tests] &&
+        [json exists $actual "test-environment"] &&
+        [json exists $actual "test-environment" tclsh] &&
+        [string length [json get $actual test-environment tclsh]] > 0
     }
 }
 customMatch exercismResultFiles exercismResultFilesMatch

--- a/tests/test_all.test
+++ b/tests/test_all.test
@@ -1,0 +1,29 @@
+#!/usr/bin/env tclsh
+package require tcltest
+namespace import ::tcltest::*
+set PWD [pwd] ;# expected to be in the repo root dir
+
+source [file join $PWD tests testHelpers.tcl]
+
+set RUN_SCRIPT [file join $PWD bin run.tcl]
+set env(RUN_ALL) yes
+
+set test_dirs [glob -directory [file join $PWD tests] -types d *]
+
+foreach dir $test_dirs {
+    set slug [file tail $dir]
+    test $slug $slug -body {
+        set actual [file join $dir results.json]
+        file delete $actual
+
+        set out [exec $RUN_SCRIPT $slug $dir $dir]
+
+        if {![file exists $actual]} {
+            return -code error "no results.json file for $dir"
+        } else {
+            string cat $actual
+        }
+    } -returnCodes ok -match exercismResultFiles -result [file join $dir expected_results.json]
+}
+
+cleanupTests

--- a/tests/test_all.test
+++ b/tests/test_all.test
@@ -1,14 +1,12 @@
 #!/usr/bin/env tclsh
 package require tcltest
 namespace import ::tcltest::*
+configure -verbose {body error msec}
+
 set PWD [pwd] ;# expected to be in the repo root dir
-
-source [file join $PWD tests testHelpers.tcl]
-
-set RUN_SCRIPT [file join $PWD bin run.tcl]
-set env(RUN_ALL) yes
-
+set run [file join $PWD bin run.tcl]
 set test_dirs [glob -directory [file join $PWD tests] -types d *]
+source [file join $PWD tests testHelpers.tcl]
 
 foreach dir $test_dirs {
     set slug [file tail $dir]
@@ -16,7 +14,7 @@ foreach dir $test_dirs {
         set actual [file join $dir results.json]
         file delete $actual
 
-        set out [exec $RUN_SCRIPT $slug $dir $dir]
+        set out [exec $run $slug $dir $dir]
 
         if {![file exists $actual]} {
             return -code error "no results.json file for $dir"


### PR DESCRIPTION
Adds the "test-environment" key to results.json
```json
{
    "version":          2,
    "status":           "fail",
    "test-environment": {
        "tclsh": "8.6.10"
    },
    "message":          null,
    "tests":            [
        ...
    ]
}
```

Fixes #25 