### PR TITLE
Don't let the user's tcltest verbosity config commands override what the test-runner needs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
-# This image includes the 3rd party rl_json library:
-#   https://github.com/RubyLane/rl_json
-FROM cyanogilvie/tcl
-
+# https://hub.docker.com/r/cyanogilvie/tcl
+# includes, among other packages:
+#   tcl         8.7a4   http://tcl.tk/software/tcltk/8.7.html 
+#   Thread      2.8.6   https://core.tcl-lang.org/thread/dir?ci=tip 
+#   tcllib      1.20    https://core.tcl-lang.org/tcllib/doc/tcllib-1-20/embedded/md/toc.md 
+#   rl_json     0.11.0  https://github.com/RubyLane/rl_json
+#   parse_args  0.3.1   https://github.com/RubyLane/parse_args 
+FROM cyanogilvie/tcl:8.7pre3
 COPY . /opt/test-runner
 WORKDIR /opt/test-runner
 ENV RUN_ALL=true

--- a/bin/run.tcl
+++ b/bin/run.tcl
@@ -70,6 +70,10 @@ proc extraTestVerbosity {slug testsFile} {
     set fhIn [open $testsFile r]
     set fhOut [open $verboseTestsFile w]
     while {[gets $fhIn line] != -1} {
+        if {[regexp {^\s*configure\s+-verbose} $line]} {
+            # ignore user's verbose settings
+            set line "## $line"
+        }
         puts $fhOut $line
         if {[string match "namespace import *tcltest*" $line]} {
             puts $fhOut "configure -verbose {start body error pass}"
@@ -130,8 +134,9 @@ proc getTestBodies {testsFile} {
     $i expose source source
     $i eval {
         rename source tcl_source
-        # turn these into no-op commands
-        foreach cmd {package namespace source skip cleanupTests} {
+        # turn these tcl and tcltest commands into no-ops,
+        # including "unknown" to ignore any unknown commands
+        foreach cmd {package namespace source skip cleanupTests configure unknown} {
             proc $cmd {args} {}
         }
         # don't actually run the test,

--- a/tests/broken-test-output/broken-test-output.test
+++ b/tests/broken-test-output/broken-test-output.test
@@ -1,0 +1,17 @@
+#!/usr/bin/env tclsh
+package require tcltest
+namespace import ::tcltest::*
+source ../testHelpers.tcl
+
+test test1 "success" -body {
+    puts "some output"
+    set result ok
+} -returnCodes ok -result ok
+
+test test2 "broken" -body {
+    puts "start of broken test"
+    exec kill [pid]
+    puts "end of broken test"
+} -returnCodes ok -result ok
+
+cleanupTests

--- a/tests/broken-test-output/expected_results.json
+++ b/tests/broken-test-output/expected_results.json
@@ -1,0 +1,25 @@
+{
+    "version":          2,
+    "status":           "fail",
+    "test-exit-status": -1,
+    "test-environment": {
+        "tclsh": "8.6.10"
+    },
+    "message":          null,
+    "tests":            [
+        {
+            "name":      "test1",
+            "status":    "pass",
+            "output":    "some output",
+            "message":   null,
+            "test_code": "puts \"some output\"\n    set result ok"
+        },
+        {
+            "name":      "test2",
+            "status":    "fail",
+            "message":   null,
+            "output":    "start of broken test\nchild killed: software termination signal",
+            "test_code": "puts \"start of broken test\"\n    exec kill [pid]\n    puts \"end of broken test\""
+        }
+    ]
+}

--- a/tests/example-unexpected-test-commands/example-unexpected-test-commands.tcl
+++ b/tests/example-unexpected-test-commands/example-unexpected-test-commands.tcl
@@ -1,0 +1,4 @@
+#!/usr/bin/env tclsh
+proc a_procedure {args} {
+    return "bang!"
+}

--- a/tests/example-unexpected-test-commands/example-unexpected-test-commands.test
+++ b/tests/example-unexpected-test-commands/example-unexpected-test-commands.test
@@ -12,3 +12,5 @@ a_procedure
 test test1 "a test" -body {
     a_procedure unused arguments
 } -returnCodes ok -result "bang!"
+
+cleanupTests

--- a/tests/example-unexpected-test-commands/example-unexpected-test-commands.test
+++ b/tests/example-unexpected-test-commands/example-unexpected-test-commands.test
@@ -1,0 +1,14 @@
+#!/usr/bin/env tclsh
+package require tcltest
+namespace import ::tcltest::*
+source ../testHelpers.tcl
+
+configure -verbose {error msec}
+
+source example-unexpected-test-commands.tcl
+
+a_procedure
+
+test test1 "a test" -body {
+    a_procedure unused arguments
+} -returnCodes ok -result "bang!"

--- a/tests/example-unexpected-test-commands/expected_results.json
+++ b/tests/example-unexpected-test-commands/expected_results.json
@@ -1,0 +1,17 @@
+{
+    "version":          2,
+    "status":           "pass",
+    "test-environment": {
+        "tclsh": "8.6.10"
+    },
+    "message":          null,
+    "tests":            [
+        {
+            "name":      "test1",
+            "status":    "pass",
+            "output":    null,
+            "message":   null,
+            "test_code": "a_procedure unused arguments"
+        }
+    ]
+}

--- a/tests/testHelpers.tcl
+++ b/tests/testHelpers.tcl
@@ -47,7 +47,10 @@ proc booleanMatch {expected actual} {
 customMatch boolean booleanMatch
 
 
-# for testing the test runner, compare the actual results.json to the expected_results.json
+# For testing the test runner, compare the actual results.json to the expected_results.json
+# Just check that the test-environment object exists with a value, don't check
+# for equality with the expected results: the tclsh version locally and in
+# docker may well be different.
 
 proc exercismResultFilesMatch {expected_file actual_file} {
     set actual [readfile $actual_file]


### PR DESCRIPTION
Also, pin the docker image tag to prevent surprises.

Relates to exercism/exercism#6366